### PR TITLE
Add Supabase and Basic Auth (Simple) Authentication Provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 AUTH0_DOMAIN="YOUR_DOMAIN"
 AUTH0_CLIENT_ID="YOUR_CLIENT_ID"
 AUTH0_REDIRECT_URI="YOUR_REDIRECT_URI"
+# Set default auth provider: "auth0" or "basic"
+DEFAULT_AUTH_PROVIDER="auth0"
+# Basic Auth credentials (for demonstration only)
+BASIC_AUTH_USERNAME="admin"
+BASIC_AUTH_PASSWORD="password"

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,14 @@
 AUTH0_DOMAIN="YOUR_DOMAIN"
 AUTH0_CLIENT_ID="YOUR_CLIENT_ID"
 AUTH0_REDIRECT_URI="YOUR_REDIRECT_URI"
-# Set default auth provider: "auth0" or "basic"
-DEFAULT_AUTH_PROVIDER="auth0"
+
 # Basic Auth credentials (for demonstration only)
 BASIC_AUTH_USERNAME="admin"
 BASIC_AUTH_PASSWORD="password"
+
+# Supabase credentials
+SUPABASE_URL="YOUR_SUPABASE_URL"
+SUPABASE_ANON_KEY="YOUR_SUPABASE_ANON_KEY"
+
+# Set default auth provider: "auth0" or "basic" or "supabase"
+DEFAULT_AUTH_PROVIDER="auth0"

--- a/.vitepress/auth/authService.ts
+++ b/.vitepress/auth/authService.ts
@@ -1,4 +1,6 @@
-import { readonly, ref, computed, Ref, shallowRef } from "vue";
+import { readonly, ref, computed, Ref } from "vue";
+import * as auth0Service from "./auth0Service";
+import * as basicAuthService from "./basicAuthService";
 
 // Типы для авторизации
 export type AuthProvider = "auth0" | "basic";
@@ -11,51 +13,59 @@ export interface AuthState {
   error: Ref<any>;
 }
 
-// Адаптер для auth0Service
-async function createAuth0Adapter() {
-  const auth0Module = await import("./auth0Service");
-  return {
-    useAuth: () => {
-      const auth = auth0Module.useAuth();
-      return {
-        isAuthenticated: auth.isAuthenticated,
-        user: auth.user,
-        loading: auth.loading,
-        error: auth.error,
-      };
-    },
-    initAuth: auth0Module.initAuth,
-    login: async (options?: any) => {
-      await auth0Module.login(options);
-      return true; // auth0 не возвращает результат, всегда считаем успешным
-    },
-    logout: auth0Module.logout,
-  };
+// Интерфейс для адаптера аутентификации
+interface AuthAdapter {
+  useAuth: () => AuthState;
+  initAuth: () => Promise<void>;
+  login: (options?: any) => Promise<boolean>;
+  logout: () => Promise<void>;
 }
 
+// Адаптер для auth0Service
+const auth0Adapter: AuthAdapter = {
+  useAuth: () => {
+    const auth = auth0Service.useAuth();
+    return {
+      isAuthenticated: auth.isAuthenticated,
+      user: auth.user,
+      loading: auth.loading,
+      error: auth.error,
+    };
+  },
+  initAuth: auth0Service.initAuth,
+  login: async (options?: any) => {
+    await auth0Service.login(options);
+    return true; // auth0 не возвращает результат, всегда считаем успешным
+  },
+  logout: auth0Service.logout,
+};
+
 // Адаптер для basicAuthService
-async function createBasicAuthAdapter() {
-  const basicAuthModule = await import("./basicAuthService");
-  return {
-    useAuth: () => {
-      const auth = basicAuthModule.useBasicAuth();
-      return {
-        isAuthenticated: auth.isAuthenticated,
-        user: auth.user,
-        loading: auth.loading,
-        error: auth.error,
-      };
-    },
-    initAuth: basicAuthModule.initAuth,
-    login: async (options?: any) => {
-      if (options && options.username && options.password) {
-        return await basicAuthModule.login(options.username, options.password);
-      }
-      return false;
-    },
-    logout: basicAuthModule.logout,
-  };
-}
+const basicAuthAdapter: AuthAdapter = {
+  useAuth: () => {
+    const auth = basicAuthService.useBasicAuth();
+    return {
+      isAuthenticated: auth.isAuthenticated,
+      user: auth.user,
+      loading: auth.loading,
+      error: auth.error,
+    };
+  },
+  initAuth: basicAuthService.initAuth,
+  login: async (options?: any) => {
+    if (options && options.username && options.password) {
+      return await basicAuthService.login(options.username, options.password);
+    }
+    return false;
+  },
+  logout: basicAuthService.logout,
+};
+
+// Реестр адаптеров
+const adapters: Record<AuthProvider, AuthAdapter> = {
+  auth0: auth0Adapter,
+  basic: basicAuthAdapter,
+};
 
 // Получаем провайдер из переменных окружения
 const defaultProvider =
@@ -67,102 +77,47 @@ const currentProvider = ref<AuthProvider>(defaultProvider);
 // Метаданные аутентификации
 const lastLoginAttempt = ref<Date | null>(null);
 
-// Интерфейс для провайдера аутентификации с адаптерами
-interface AuthAdapter {
-  useAuth: () => AuthState;
-  initAuth: () => Promise<void>;
-  login: (options?: any) => Promise<boolean>;
-  logout: () => Promise<void>;
-}
-
-// Ссылка на текущий адаптер
-const authAdapter = shallowRef<AuthAdapter | null>(null);
-
-// Флаг загрузки модуля
-const isModuleLoading = ref(false);
-
-// Загружаем адаптер аутентификации
-async function loadAuthAdapter(provider: AuthProvider): Promise<AuthAdapter> {
-  isModuleLoading.value = true;
-  try {
-    let adapter: AuthAdapter;
-
-    if (provider === "auth0") {
-      adapter = await createAuth0Adapter();
-    } else if (provider === "basic") {
-      adapter = await createBasicAuthAdapter();
-    } else {
-      throw new Error(`Неподдерживаемый провайдер аутентификации: ${provider}`);
-    }
-
-    authAdapter.value = adapter;
-    return adapter;
-  } finally {
-    isModuleLoading.value = false;
-  }
-}
-
-// Получаем или загружаем текущий адаптер
-async function getAuthAdapter(): Promise<AuthAdapter> {
-  if (!authAdapter.value) {
-    return await loadAuthAdapter(currentProvider.value);
-  }
-  return authAdapter.value;
+// Получаем текущий адаптер
+function getCurrentAdapter(): AuthAdapter {
+  return adapters[currentProvider.value];
 }
 
 // Экспортируем функцию смены провайдера
-export async function setAuthProvider(provider: AuthProvider) {
+export function setAuthProvider(provider: AuthProvider) {
   if (provider !== currentProvider.value) {
     currentProvider.value = provider;
-    await loadAuthAdapter(provider);
   }
 }
 
 // Инициализация сервиса
 export async function initAuth() {
-  const adapter = await getAuthAdapter();
-  await adapter.initAuth();
+  await getCurrentAdapter().initAuth();
 }
 
 // Метод входа
 export async function login(options?: any) {
   lastLoginAttempt.value = new Date();
-  const adapter = await getAuthAdapter();
-  return await adapter.login(options);
+  return await getCurrentAdapter().login(options);
 }
 
 // Метод выхода
 export async function logout() {
   lastLoginAttempt.value = null;
-  const adapter = await getAuthAdapter();
-  await adapter.logout();
+  await getCurrentAdapter().logout();
 }
 
 // Пользовательский хук для компонентов Vue
 export const useAuthService = () => {
-  // Создаем вычисляемые свойства, которые будут обновляться при изменении адаптера
-  const isAuthenticated = computed(() => {
-    const adapter = authAdapter.value;
-    return adapter ? adapter.useAuth().isAuthenticated.value : false;
-  });
+  // Создаем вычисляемые свойства на основе текущего адаптера
+  const isAuthenticated = computed(
+    () => getCurrentAdapter().useAuth().isAuthenticated.value
+  );
 
-  const user = computed(() => {
-    const adapter = authAdapter.value;
-    return adapter ? adapter.useAuth().user.value : null;
-  });
+  const user = computed(() => getCurrentAdapter().useAuth().user.value);
 
-  const loading = computed(() => {
-    const adapter = authAdapter.value;
-    return (
-      isModuleLoading.value ||
-      (adapter ? adapter.useAuth().loading.value : true)
-    );
-  });
+  const loading = computed(() => getCurrentAdapter().useAuth().loading.value);
 
-  const error = computed(() => {
-    const adapter = authAdapter.value;
-    return adapter ? adapter.useAuth().error.value : null;
-  });
+  const error = computed(() => getCurrentAdapter().useAuth().error.value);
 
   return {
     isAuthenticated,

--- a/.vitepress/auth/authService.ts
+++ b/.vitepress/auth/authService.ts
@@ -1,0 +1,48 @@
+import {
+  useAuth,
+  initAuth as initAuth0,
+  login as auth0Login,
+  logout as auth0Logout,
+} from "./auth0Service";
+import { readonly, ref } from "vue";
+
+// Дополнительное состояние сервиса, если оно необходимо
+const lastLoginAttempt = ref<Date | null>(null);
+
+// Инициализация сервиса
+export async function initAuth() {
+  // Использование базовой инициализации из auth0Service
+  await initAuth0();
+}
+
+// Оборачиваем базовый метод логина
+export async function login(options?: any) {
+  // Добавляем простой функционал отслеживания последней попытки входа
+  lastLoginAttempt.value = new Date();
+
+  // Вызываем оригинальный метод логина
+  await auth0Login(options);
+}
+
+// Оборачиваем базовый метод выхода
+export async function logout() {
+  // Очищаем дополнительное состояние
+  lastLoginAttempt.value = null;
+
+  // Вызываем оригинальный метод логаута
+  await auth0Logout();
+}
+
+// Пользовательский хук для компонентов Vue
+export const useAuthService = () => {
+  const auth = useAuth();
+
+  // Возвращаем расширенный интерфейс
+  return {
+    ...auth, // Все свойства из базового auth0
+    lastLoginAttempt: readonly(lastLoginAttempt),
+    login,
+    logout,
+    initAuth,
+  };
+};

--- a/.vitepress/auth/authService.ts
+++ b/.vitepress/auth/authService.ts
@@ -4,42 +4,103 @@ import {
   login as auth0Login,
   logout as auth0Logout,
 } from "./auth0Service";
-import { readonly, ref } from "vue";
+import {
+  useBasicAuth,
+  initAuth as initBasicAuth,
+  login as basicAuthLogin,
+  logout as basicAuthLogout,
+} from "./basicAuthService";
+import { readonly, ref, computed } from "vue";
+
+// Определение доступных провайдеров аутентификации
+export type AuthProvider = "auth0" | "basic";
+
+// Получаем провайдер из переменных окружения
+const defaultProvider =
+  (import.meta.env.DEFAULT_AUTH_PROVIDER as AuthProvider) || "auth0";
+
+// Текущий провайдер аутентификации
+const currentProvider = ref<AuthProvider>(defaultProvider);
 
 // Дополнительное состояние сервиса, если оно необходимо
 const lastLoginAttempt = ref<Date | null>(null);
 
 // Инициализация сервиса
 export async function initAuth() {
-  // Использование базовой инициализации из auth0Service
-  await initAuth0();
+  // Использование соответствующей инициализации в зависимости от провайдера
+  if (currentProvider.value === "auth0") {
+    await initAuth0();
+  } else {
+    await initBasicAuth();
+  }
 }
 
-// Оборачиваем базовый метод логина
+// Оборачиваем метод логина
 export async function login(options?: any) {
   // Добавляем простой функционал отслеживания последней попытки входа
   lastLoginAttempt.value = new Date();
 
-  // Вызываем оригинальный метод логина
-  await auth0Login(options);
+  // Вызываем соответствующий метод логина
+  if (currentProvider.value === "auth0") {
+    await auth0Login(options);
+    return true;
+  } else {
+    // Для Basic Auth ожидаем username и password
+    if (options && options.username && options.password) {
+      return await basicAuthLogin(options.username, options.password);
+    }
+    return false;
+  }
 }
 
-// Оборачиваем базовый метод выхода
+// Оборачиваем метод выхода
 export async function logout() {
   // Очищаем дополнительное состояние
   lastLoginAttempt.value = null;
 
-  // Вызываем оригинальный метод логаута
-  await auth0Logout();
+  // Вызываем соответствующий метод логаута
+  if (currentProvider.value === "auth0") {
+    await auth0Logout();
+  } else {
+    await basicAuthLogout();
+  }
 }
 
 // Пользовательский хук для компонентов Vue
 export const useAuthService = () => {
-  const auth = useAuth();
+  const auth0 = useAuth();
+  const basicAuth = useBasicAuth();
+
+  // Вычисляемые свойства на основе текущего провайдера
+  const isAuthenticated = computed(() =>
+    currentProvider.value === "auth0"
+      ? auth0.isAuthenticated.value
+      : basicAuth.isAuthenticated.value
+  );
+
+  const user = computed(() =>
+    currentProvider.value === "auth0" ? auth0.user.value : basicAuth.user.value
+  );
+
+  const loading = computed(() =>
+    currentProvider.value === "auth0"
+      ? auth0.loading.value
+      : basicAuth.loading.value
+  );
+
+  const error = computed(() =>
+    currentProvider.value === "auth0"
+      ? auth0.error.value
+      : basicAuth.error.value
+  );
 
   // Возвращаем расширенный интерфейс
   return {
-    ...auth, // Все свойства из базового auth0
+    isAuthenticated,
+    user,
+    loading,
+    error,
+    currentProvider: readonly(currentProvider),
     lastLoginAttempt: readonly(lastLoginAttempt),
     login,
     logout,

--- a/.vitepress/auth/authService.ts
+++ b/.vitepress/auth/authService.ts
@@ -1,9 +1,10 @@
 import { readonly, ref, computed, Ref } from "vue";
 import * as auth0Service from "./auth0Service";
 import * as basicAuthService from "./basicAuthService";
+import * as supabaseService from "./supabaseService";
 
 // Authentication types
-export type AuthProvider = "auth0" | "basic";
+export type AuthProvider = "auth0" | "basic" | "supabase";
 
 // Common interface for authentication providers
 export interface AuthState {
@@ -61,10 +62,29 @@ const basicAuthAdapter: AuthAdapter = {
   logout: basicAuthService.logout,
 };
 
+// Adapter for supabaseService
+const supabaseAdapter: AuthAdapter = {
+  useAuth: () => {
+    const auth = supabaseService.useSupabaseAuth();
+    return {
+      isAuthenticated: auth.isAuthenticated,
+      user: auth.user,
+      loading: auth.loading,
+      error: auth.error,
+    };
+  },
+  initAuth: supabaseService.initAuth,
+  login: async (options?: any) => {
+    return await supabaseService.login(options);
+  },
+  logout: supabaseService.logout,
+};
+
 // Registry of adapters
 const adapters: Record<AuthProvider, AuthAdapter> = {
   auth0: auth0Adapter,
   basic: basicAuthAdapter,
+  supabase: supabaseAdapter,
 };
 
 // Get provider from environment variables

--- a/.vitepress/auth/basicAuthService.ts
+++ b/.vitepress/auth/basicAuthService.ts
@@ -1,0 +1,84 @@
+import { ref, readonly } from "vue";
+
+// Basic Auth credentials from environment variables
+const validUsername = import.meta.env.BASIC_AUTH_USERNAME || "admin";
+const validPassword = import.meta.env.BASIC_AUTH_PASSWORD || "password";
+
+// State
+const isAuthenticated = ref(false);
+const user = ref<{ username: string } | null>(null);
+const loading = ref(false);
+const error = ref<string | null>(null);
+
+// Initialize auth state from localStorage if available
+export async function initAuth() {
+  loading.value = true;
+  try {
+    // Check if we have stored auth in localStorage
+    const storedAuth = localStorage.getItem("basic_auth_user");
+    if (storedAuth) {
+      const userData = JSON.parse(storedAuth);
+      user.value = userData;
+      isAuthenticated.value = true;
+    }
+  } catch (e) {
+    console.error("Error initializing Basic Auth:", e);
+    error.value = "Failed to initialize authentication";
+  } finally {
+    loading.value = false;
+  }
+}
+
+// Login with username and password
+export async function login(
+  username: string,
+  password: string
+): Promise<boolean> {
+  loading.value = true;
+  error.value = null;
+
+  try {
+    // Simple validation against environment variables
+    if (username === validUsername && password === validPassword) {
+      // Set authentication state
+      isAuthenticated.value = true;
+      user.value = { username };
+
+      // Store in localStorage for persistence
+      localStorage.setItem("basic_auth_user", JSON.stringify({ username }));
+      return true;
+    } else {
+      error.value = "Invalid username or password";
+      return false;
+    }
+  } catch (e) {
+    console.error("Login error:", e);
+    error.value = "Login failed";
+    return false;
+  } finally {
+    loading.value = false;
+  }
+}
+
+// Logout
+export async function logout() {
+  // Clear auth state
+  isAuthenticated.value = false;
+  user.value = null;
+
+  // Remove from localStorage
+  localStorage.removeItem("basic_auth_user");
+}
+
+// Expose the auth state and methods
+export const useBasicAuth = () => {
+  return {
+    isAuthenticated: readonly(isAuthenticated),
+    user: readonly(user),
+    loading: readonly(loading),
+    error: readonly(error),
+    login,
+    logout,
+    initAuth,
+  };
+};

--- a/.vitepress/auth/supabaseService.ts
+++ b/.vitepress/auth/supabaseService.ts
@@ -5,13 +5,13 @@ import { createClient, Session, AuthChangeEvent } from "@supabase/supabase-js";
 const supabaseUrl = import.meta.env.SUPABASE_URL || "";
 const supabaseAnonKey = import.meta.env.SUPABASE_ANON_KEY || "";
 
-// Проверяем наличие необходимых переменных окружения
+// Check for required environment variables
 if (!supabaseUrl) {
-  console.error("SUPABASE_URL не установлен в переменных окружения.");
+  console.error("SUPABASE_URL is not set in environment variables.");
 }
 
 if (!supabaseAnonKey) {
-  console.error("SUPABASE_ANON_KEY не установлен в переменных окружения.");
+  console.error("SUPABASE_ANON_KEY is not set in environment variables.");
 }
 
 // Initialize Supabase client only if we have URL and key
@@ -31,10 +31,10 @@ export async function initAuth() {
   loading.value = true;
 
   try {
-    // Проверяем, инициализирован ли клиент Supabase
+    // Check if Supabase client is initialized
     if (!supabase) {
       throw new Error(
-        "Клиент Supabase не был инициализирован. Проверьте переменные окружения SUPABASE_URL и SUPABASE_ANON_KEY."
+        "Supabase client was not initialized. Check the SUPABASE_URL and SUPABASE_ANON_KEY environment variables."
       );
     }
 
@@ -76,10 +76,10 @@ export async function login(options?: any): Promise<boolean> {
   error.value = null;
 
   try {
-    // Проверяем, инициализирован ли клиент Supabase
+    // Check if Supabase client is initialized
     if (!supabase) {
       throw new Error(
-        "Клиент Supabase не был инициализирован. Проверьте переменные окружения SUPABASE_URL и SUPABASE_ANON_KEY."
+        "Supabase client was not initialized. Check the SUPABASE_URL and SUPABASE_ANON_KEY environment variables."
       );
     }
 
@@ -119,10 +119,10 @@ export async function login(options?: any): Promise<boolean> {
 // Logout
 export async function logout() {
   try {
-    // Проверяем, инициализирован ли клиент Supabase
+    // Check if Supabase client is initialized
     if (!supabase) {
       throw new Error(
-        "Клиент Supabase не был инициализирован. Проверьте переменные окружения SUPABASE_URL и SUPABASE_ANON_KEY."
+        "Supabase client was not initialized. Check the SUPABASE_URL and SUPABASE_ANON_KEY environment variables."
       );
     }
 

--- a/.vitepress/auth/supabaseService.ts
+++ b/.vitepress/auth/supabaseService.ts
@@ -1,0 +1,155 @@
+import { ref, readonly } from "vue";
+import { createClient, Session, AuthChangeEvent } from "@supabase/supabase-js";
+
+// Environment variables
+const supabaseUrl = import.meta.env.SUPABASE_URL || "";
+const supabaseAnonKey = import.meta.env.SUPABASE_ANON_KEY || "";
+
+// Проверяем наличие необходимых переменных окружения
+if (!supabaseUrl) {
+  console.error("SUPABASE_URL не установлен в переменных окружения.");
+}
+
+if (!supabaseAnonKey) {
+  console.error("SUPABASE_ANON_KEY не установлен в переменных окружения.");
+}
+
+// Initialize Supabase client only if we have URL and key
+const supabase =
+  supabaseUrl && supabaseAnonKey
+    ? createClient(supabaseUrl, supabaseAnonKey)
+    : null;
+
+// State
+const isAuthenticated = ref(false);
+const user = ref<any>(null);
+const loading = ref(false);
+const error = ref<Error | null>(null);
+
+// Initialize auth state
+export async function initAuth() {
+  loading.value = true;
+
+  try {
+    // Проверяем, инициализирован ли клиент Supabase
+    if (!supabase) {
+      throw new Error(
+        "Клиент Supabase не был инициализирован. Проверьте переменные окружения SUPABASE_URL и SUPABASE_ANON_KEY."
+      );
+    }
+
+    // Get current session
+    const { data, error: sessionError } = await supabase.auth.getSession();
+
+    if (sessionError) {
+      throw sessionError;
+    }
+
+    if (data?.session) {
+      isAuthenticated.value = true;
+      user.value = data.session.user;
+    }
+
+    // Setup auth state change listener
+    supabase.auth.onAuthStateChange(
+      (event: AuthChangeEvent, session: Session | null) => {
+        if (event === "SIGNED_IN" && session) {
+          isAuthenticated.value = true;
+          user.value = session.user;
+        } else if (event === "SIGNED_OUT") {
+          isAuthenticated.value = false;
+          user.value = null;
+        }
+      }
+    );
+  } catch (e) {
+    error.value = e as Error;
+    console.error("Supabase auth initialization error:", e);
+  } finally {
+    loading.value = false;
+  }
+}
+
+// Login with email and password
+export async function login(options?: any): Promise<boolean> {
+  loading.value = true;
+  error.value = null;
+
+  try {
+    // Проверяем, инициализирован ли клиент Supabase
+    if (!supabase) {
+      throw new Error(
+        "Клиент Supabase не был инициализирован. Проверьте переменные окружения SUPABASE_URL и SUPABASE_ANON_KEY."
+      );
+    }
+
+    if (!options || !options.email || !options.password) {
+      error.value = new Error("Email and password are required");
+      return false;
+    }
+
+    const { data, error: signInError } = await supabase.auth.signInWithPassword(
+      {
+        email: options.email,
+        password: options.password,
+      }
+    );
+
+    if (signInError) {
+      error.value = signInError;
+      return false;
+    }
+
+    if (data?.user) {
+      user.value = data.user;
+      isAuthenticated.value = true;
+      return true;
+    }
+
+    return false;
+  } catch (e) {
+    error.value = e as Error;
+    console.error("Login error:", e);
+    return false;
+  } finally {
+    loading.value = false;
+  }
+}
+
+// Logout
+export async function logout() {
+  try {
+    // Проверяем, инициализирован ли клиент Supabase
+    if (!supabase) {
+      throw new Error(
+        "Клиент Supabase не был инициализирован. Проверьте переменные окружения SUPABASE_URL и SUPABASE_ANON_KEY."
+      );
+    }
+
+    const { error: signOutError } = await supabase.auth.signOut();
+
+    if (signOutError) {
+      throw signOutError;
+    }
+
+    isAuthenticated.value = false;
+    user.value = null;
+  } catch (e) {
+    error.value = e as Error;
+    console.error("Logout error:", e);
+  }
+}
+
+// Exposed state and methods
+export const useSupabaseAuth = () => {
+  return {
+    isAuthenticated: readonly(isAuthenticated),
+    user: readonly(user),
+    loading: readonly(loading),
+    error: readonly(error),
+    login,
+    logout,
+    initAuth,
+    supabase, // Expose supabase client for advanced usage
+  };
+};

--- a/.vitepress/components/AuthGuard.vue
+++ b/.vitepress/components/AuthGuard.vue
@@ -14,12 +14,12 @@
 </template>
 
 <script setup lang="ts">
-import { useAuth } from '../auth/auth0Service';
+import { useAuthService } from '../auth/authService';
 import { useData } from 'vitepress';
 import { onMounted, computed } from 'vue';
 
 const { frontmatter } = useData();
-const { initAuth, login, isAuthenticated, loading } = useAuth();
+const { initAuth, login, isAuthenticated, loading } = useAuthService();
 
 const requiresAuth = computed(() => {
   return frontmatter.value.protected === true;
@@ -59,8 +59,13 @@ onMounted(async () => {
 }
 
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 .auth-login {

--- a/.vitepress/components/AuthGuard.vue
+++ b/.vitepress/components/AuthGuard.vue
@@ -8,50 +8,7 @@
       <h2>Authentication Required</h2>
       <p>This content is protected. Please log in to continue.</p>
 
-      <!-- Auth0 Login -->
-      <div v-if="currentProvider === 'auth0'">
-        <button class="login-button" @click="handleAuth0Login">Log In</button>
-      </div>
-
-      <!-- Supabase Login Form -->
-      <div v-else-if="currentProvider === 'supabase'" class="supabase-auth-form">
-        <div v-if="loginError" class="auth-error">
-          {{ loginError }}
-        </div>
-        <form @submit.prevent="handleSupabaseLogin">
-          <div class="form-group">
-            <label for="email">Email</label>
-            <input type="email" id="email" v-model="email" placeholder="Enter email" required />
-          </div>
-          <div class="form-group">
-            <label for="supabasePassword">Password</label>
-            <input type="password" id="supabasePassword" v-model="supabasePassword" placeholder="Enter password"
-              required />
-          </div>
-          <button type="submit" class="login-button">Log In</button>
-        </form>
-      </div>
-
-      <!-- Basic Auth Login Form -->
-      <div v-else class="basic-auth-form">
-        <div v-if="loginError" class="auth-error">
-          {{ loginError }}
-        </div>
-        <form @submit.prevent="handleBasicLogin">
-          <div class="form-group">
-            <label for="username">Username</label>
-            <input type="text" id="username" v-model="username" placeholder="Enter username" required />
-          </div>
-          <div class="form-group">
-            <label for="password">Password</label>
-            <input type="password" id="password" v-model="password" placeholder="Enter password" required />
-          </div>
-          <button type="submit" class="login-button">Log In</button>
-        </form>
-        <div class="login-info">
-          <small>Default credentials: admin / password</small>
-        </div>
-      </div>
+      <LoginForm buttonText="Log In" :showHelperText="currentProvider === 'basic'" />
     </div>
   </div>
   <slot v-else></slot>
@@ -60,59 +17,21 @@
 <script setup lang="ts">
 import { useAuthService } from '../auth/authService';
 import { useData } from 'vitepress';
-import { onMounted, computed, ref } from 'vue';
+import { onMounted, computed } from 'vue';
+import LoginForm from './LoginForm.vue';
 
 const { frontmatter } = useData();
 const {
   initAuth,
-  login,
   isAuthenticated,
   loading,
   currentProvider,
   error: authError
 } = useAuthService();
 
-// Basic Auth form state
-const username = ref('');
-const password = ref('');
-// Supabase form state
-const email = ref('');
-const supabasePassword = ref('');
-const loginError = ref<string | null>(null);
-
 const requiresAuth = computed(() => {
   return frontmatter.value.protected === true;
 });
-
-const handleAuth0Login = () => {
-  login();
-};
-
-const handleBasicLogin = async () => {
-  loginError.value = null;
-
-  const success = await login({
-    username: username.value,
-    password: password.value
-  });
-
-  if (!success) {
-    loginError.value = 'Invalid username or password';
-  }
-};
-
-const handleSupabaseLogin = async () => {
-  loginError.value = null;
-
-  const success = await login({
-    email: email.value,
-    password: supabasePassword.value
-  });
-
-  if (!success) {
-    loginError.value = 'Invalid email or password';
-  }
-};
 
 const isBrowser = typeof window !== 'undefined';
 
@@ -167,68 +86,5 @@ onMounted(async () => {
   border-radius: 8px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   text-align: center;
-}
-
-.login-button {
-  margin-top: 1rem;
-  padding: 0.75rem 1.5rem;
-  background-color: var(--vp-c-brand);
-  color: white;
-  border: none;
-  border-radius: 4px;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: background-color 0.2s;
-  width: 100%;
-}
-
-.login-button:hover {
-  background-color: var(--vp-c-brand-dark);
-}
-
-/* Basic Auth Form Styles */
-.basic-auth-form {
-  margin-top: 1rem;
-  text-align: left;
-}
-
-.form-group {
-  margin-bottom: 1rem;
-}
-
-.form-group label {
-  display: block;
-  margin-bottom: 0.5rem;
-  font-weight: 500;
-}
-
-.form-group input {
-  width: 100%;
-  padding: 0.75rem;
-  border: 1px solid var(--vp-c-divider);
-  border-radius: 4px;
-  background-color: var(--vp-c-bg);
-  font-size: 1rem;
-}
-
-.auth-error {
-  color: #e53935;
-  margin-bottom: 1rem;
-  padding: 0.5rem;
-  background-color: rgba(229, 57, 53, 0.1);
-  border-radius: 4px;
-  text-align: center;
-}
-
-.login-info {
-  margin-top: 1rem;
-  text-align: center;
-  color: var(--vp-c-text-2);
-}
-
-/* Supabase Auth Form Styles */
-.supabase-auth-form {
-  margin-top: 1rem;
-  text-align: left;
 }
 </style>

--- a/.vitepress/components/AuthGuard.vue
+++ b/.vitepress/components/AuthGuard.vue
@@ -10,7 +10,7 @@
 
       <!-- Auth0 Login -->
       <div v-if="currentProvider === 'auth0'">
-        <button class="login-button" @click="handleAuth0Login">Log In with Auth0</button>
+        <button class="login-button" @click="handleAuth0Login">Log In</button>
       </div>
 
       <!-- Basic Auth Login Form -->

--- a/.vitepress/components/AuthGuard.vue
+++ b/.vitepress/components/AuthGuard.vue
@@ -13,6 +13,25 @@
         <button class="login-button" @click="handleAuth0Login">Log In</button>
       </div>
 
+      <!-- Supabase Login Form -->
+      <div v-else-if="currentProvider === 'supabase'" class="supabase-auth-form">
+        <div v-if="loginError" class="auth-error">
+          {{ loginError }}
+        </div>
+        <form @submit.prevent="handleSupabaseLogin">
+          <div class="form-group">
+            <label for="email">Email</label>
+            <input type="email" id="email" v-model="email" placeholder="Enter email" required />
+          </div>
+          <div class="form-group">
+            <label for="supabasePassword">Password</label>
+            <input type="password" id="supabasePassword" v-model="supabasePassword" placeholder="Enter password"
+              required />
+          </div>
+          <button type="submit" class="login-button">Log In</button>
+        </form>
+      </div>
+
       <!-- Basic Auth Login Form -->
       <div v-else class="basic-auth-form">
         <div v-if="loginError" class="auth-error">
@@ -56,6 +75,9 @@ const {
 // Basic Auth form state
 const username = ref('');
 const password = ref('');
+// Supabase form state
+const email = ref('');
+const supabasePassword = ref('');
 const loginError = ref<string | null>(null);
 
 const requiresAuth = computed(() => {
@@ -76,6 +98,19 @@ const handleBasicLogin = async () => {
 
   if (!success) {
     loginError.value = 'Invalid username or password';
+  }
+};
+
+const handleSupabaseLogin = async () => {
+  loginError.value = null;
+
+  const success = await login({
+    email: email.value,
+    password: supabasePassword.value
+  });
+
+  if (!success) {
+    loginError.value = 'Invalid email or password';
   }
 };
 
@@ -189,5 +224,11 @@ onMounted(async () => {
   margin-top: 1rem;
   text-align: center;
   color: var(--vp-c-text-2);
+}
+
+/* Supabase Auth Form Styles */
+.supabase-auth-form {
+  margin-top: 1rem;
+  text-align: left;
 }
 </style>

--- a/.vitepress/components/LoginButton.vue
+++ b/.vitepress/components/LoginButton.vue
@@ -14,6 +14,7 @@
 
 <script setup lang="ts">
 import { useAuthService } from '../auth/authService';
+import { withBase } from 'vitepress';
 
 const { isAuthenticated, loading, login, currentProvider } = useAuthService();
 
@@ -24,7 +25,7 @@ const handleLogin = () => {
   } else {
     // Если используется Basic Auth, перенаправляем на защищенную страницу,
     // где появится форма Basic Auth в AuthGuard
-    window.location.href = '/markdown-examples';
+    window.location.href = withBase('/login');
   }
 };
 </script>

--- a/.vitepress/components/LoginButton.vue
+++ b/.vitepress/components/LoginButton.vue
@@ -23,8 +23,8 @@ const handleLogin = () => {
   if (currentProvider.value === 'auth0') {
     login();
   } else {
-    // Если используется Basic Auth, перенаправляем на защищенную страницу,
-    // где появится форма Basic Auth в AuthGuard
+    // Для Supabase и Basic Auth перенаправляем на страницу логина,
+    // где отобразится соответствующая форма
     window.location.href = withBase('/login');
   }
 };

--- a/.vitepress/components/LoginButton.vue
+++ b/.vitepress/components/LoginButton.vue
@@ -1,12 +1,9 @@
 <template>
-  <button 
-    v-if="!isAuthenticated && !loading" 
-    class="login-btn" 
-    @click="handleLogin"
-    title="Log in to access protected content"
-  >
+  <button v-if="!isAuthenticated && !loading" class="login-btn" @click="handleLogin"
+    title="Log in to access protected content">
     <span class="login-icon">
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"></path>
         <polyline points="10 17 15 12 10 7"></polyline>
         <line x1="15" y1="12" x2="3" y2="12"></line>
@@ -16,9 +13,9 @@
 </template>
 
 <script setup lang="ts">
-import { useAuth } from '../auth/auth0Service';
+import { useAuthService } from '../auth/authService';
 
-const { isAuthenticated, loading, login } = useAuth();
+const { isAuthenticated, loading, login } = useAuthService();
 
 const handleLogin = () => {
   login();

--- a/.vitepress/components/LoginButton.vue
+++ b/.vitepress/components/LoginButton.vue
@@ -19,12 +19,12 @@ import { withBase } from 'vitepress';
 const { isAuthenticated, loading, login, currentProvider } = useAuthService();
 
 const handleLogin = () => {
-  // Если используется Auth0, то просто вызываем login
+  // If using Auth0, simply call login
   if (currentProvider.value === 'auth0') {
     login();
   } else {
-    // Для Supabase и Basic Auth перенаправляем на страницу логина,
-    // где отобразится соответствующая форма
+    // For Supabase and Basic Auth, redirect to the login page
+    // where the appropriate form will be displayed
     window.location.href = withBase('/login');
   }
 };

--- a/.vitepress/components/LoginButton.vue
+++ b/.vitepress/components/LoginButton.vue
@@ -15,10 +15,17 @@
 <script setup lang="ts">
 import { useAuthService } from '../auth/authService';
 
-const { isAuthenticated, loading, login } = useAuthService();
+const { isAuthenticated, loading, login, currentProvider } = useAuthService();
 
 const handleLogin = () => {
-  login();
+  // Если используется Auth0, то просто вызываем login
+  if (currentProvider.value === 'auth0') {
+    login();
+  } else {
+    // Если используется Basic Auth, перенаправляем на защищенную страницу,
+    // где появится форма Basic Auth в AuthGuard
+    window.location.href = '/markdown-examples';
+  }
 };
 </script>
 

--- a/.vitepress/components/LoginForm.vue
+++ b/.vitepress/components/LoginForm.vue
@@ -1,0 +1,223 @@
+<template>
+    <div class="login-form-container">
+        <div v-if="loginError" class="auth-error">
+            {{ loginError }}
+        </div>
+
+        <!-- Auth0 Login -->
+        <div v-if="currentProvider === 'auth0'" class="login-form">
+            <button class="login-button" @click="handleAuth0Login">
+                <span class="login-icon" v-if="showIcon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"></path>
+                        <polyline points="10 17 15 12 10 7"></polyline>
+                        <line x1="15" y1="12" x2="3" y2="12"></line>
+                    </svg>
+                </span>
+                {{ buttonText }}
+            </button>
+        </div>
+
+        <!-- Supabase Login Form -->
+        <div v-else-if="currentProvider === 'supabase'" class="login-form">
+            <form @submit.prevent="handleSupabaseLogin">
+                <div class="form-group">
+                    <label for="email">Email</label>
+                    <input type="email" id="email" v-model="email" placeholder="Enter email" required />
+                </div>
+                <div class="form-group">
+                    <label for="supabasePassword">Password</label>
+                    <input type="password" id="supabasePassword" v-model="supabasePassword" placeholder="Enter password"
+                        required />
+                </div>
+                <button type="submit" class="login-button">{{ buttonText }}</button>
+            </form>
+        </div>
+
+        <!-- Basic Auth Login Form -->
+        <div v-else class="login-form">
+            <form @submit.prevent="handleBasicLogin">
+                <div class="form-group">
+                    <label for="username">Username</label>
+                    <input type="text" id="username" v-model="username" placeholder="Enter username" required />
+                </div>
+                <div class="form-group">
+                    <label for="password">Password</label>
+                    <input type="password" id="password" v-model="password" placeholder="Enter password" required />
+                </div>
+                <button type="submit" class="login-button">{{ buttonText }}</button>
+            </form>
+            <div v-if="showHelperText" class="login-info">
+                <small>Default credentials: admin / password</small>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref, defineProps, defineEmits } from 'vue';
+import { useAuthService } from '../auth/authService';
+import { withBase } from 'vitepress';
+
+const props = defineProps({
+    buttonText: {
+        type: String,
+        default: 'Sign In'
+    },
+    redirectUrl: {
+        type: String,
+        default: '/'
+    },
+    showHelperText: {
+        type: Boolean,
+        default: false
+    },
+    showIcon: {
+        type: Boolean,
+        default: false
+    }
+});
+
+const emit = defineEmits(['success', 'error']);
+
+const {
+    login,
+    currentProvider,
+} = useAuthService();
+
+// Basic Auth form state
+const username = ref('');
+const password = ref('');
+// Supabase form state
+const email = ref('');
+const supabasePassword = ref('');
+const loginError = ref<string | null>(null);
+
+const handleAuth0Login = () => {
+    login();
+};
+
+const handleBasicLogin = async () => {
+    loginError.value = null;
+
+    try {
+        const success = await login({
+            username: username.value,
+            password: password.value
+        });
+
+        if (success) {
+            emit('success');
+            if (props.redirectUrl) {
+                window.location.href = withBase(props.redirectUrl);
+            }
+        } else {
+            loginError.value = 'Invalid username or password';
+            emit('error', loginError.value);
+        }
+    } catch (error) {
+        loginError.value = 'An error occurred during login';
+        console.error('Login error:', error);
+        emit('error', loginError.value);
+    }
+};
+
+const handleSupabaseLogin = async () => {
+    loginError.value = null;
+
+    try {
+        const success = await login({
+            email: email.value,
+            password: supabasePassword.value
+        });
+
+        if (success) {
+            emit('success');
+            if (props.redirectUrl) {
+                window.location.href = withBase(props.redirectUrl);
+            }
+        } else {
+            loginError.value = 'Invalid email or password';
+            emit('error', loginError.value);
+        }
+    } catch (error) {
+        loginError.value = 'An error occurred during login';
+        console.error('Login error:', error);
+        emit('error', loginError.value);
+    }
+};
+</script>
+
+<style>
+.login-form-container {
+    width: 100%;
+}
+
+.login-form {
+    margin-bottom: 1.5rem;
+}
+
+.form-group {
+    margin-bottom: 1rem;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+}
+
+.form-group input {
+    width: 100%;
+    padding: 0.75rem;
+    border: 1px solid var(--vp-c-divider);
+    border-radius: 4px;
+    background-color: var(--vp-c-bg);
+    color: var(--vp-c-text-1);
+}
+
+.login-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: 0.75rem;
+    font-size: 1rem;
+    font-weight: 500;
+    background-color: var(--vp-c-brand);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.login-button:hover {
+    background-color: var(--vp-c-brand-dark);
+}
+
+.login-icon {
+    margin-right: 8px;
+}
+
+.auth-error {
+    background-color: #ffebee;
+    color: #c62828;
+    padding: 0.75rem;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+}
+
+.login-info {
+    margin-top: 0.75rem;
+    text-align: center;
+    color: var(--vp-c-text-2);
+}
+
+/* Dark mode adjustments */
+.dark .auth-error {
+    background-color: rgba(244, 67, 54, 0.1);
+}
+</style>

--- a/.vitepress/components/LoginPage.vue
+++ b/.vitepress/components/LoginPage.vue
@@ -3,55 +3,7 @@
         <div class="login-container">
             <h1>Sign In</h1>
 
-            <div v-if="loginError" class="auth-error">
-                {{ loginError }}
-            </div>
-
-            <!-- Auth0 Login -->
-            <div v-if="currentProvider === 'auth0'" class="login-form">
-                <button class="login-button" @click="handleAuth0Login">
-                    <span class="login-icon">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
-                            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"></path>
-                            <polyline points="10 17 15 12 10 7"></polyline>
-                            <line x1="15" y1="12" x2="3" y2="12"></line>
-                        </svg>
-                    </span>
-                    Sign In
-                </button>
-            </div>
-
-            <!-- Supabase Login Form -->
-            <div v-else-if="currentProvider === 'supabase'" class="login-form">
-                <form @submit.prevent="handleSupabaseLogin">
-                    <div class="form-group">
-                        <label for="email">Email</label>
-                        <input type="email" id="email" v-model="email" placeholder="Enter email" required />
-                    </div>
-                    <div class="form-group">
-                        <label for="supabasePassword">Password</label>
-                        <input type="password" id="supabasePassword" v-model="supabasePassword"
-                            placeholder="Enter password" required />
-                    </div>
-                    <button type="submit" class="login-button">Sign In</button>
-                </form>
-            </div>
-
-            <!-- Basic Auth Login Form -->
-            <div v-else class="login-form">
-                <form @submit.prevent="handleBasicLogin">
-                    <div class="form-group">
-                        <label for="username">Username</label>
-                        <input type="text" id="username" v-model="username" placeholder="Enter username" required />
-                    </div>
-                    <div class="form-group">
-                        <label for="password">Password</label>
-                        <input type="password" id="password" v-model="password" placeholder="Enter password" required />
-                    </div>
-                    <button type="submit" class="login-button">Sign In</button>
-                </form>
-            </div>
+            <LoginForm buttonText="Sign In" redirectUrl="/" :showIcon="true" />
 
             <div class="home-link">
                 <a :href="withBase('/')">Return to Home Page</a>
@@ -61,71 +13,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
-import { useAuthService } from '../auth/authService';
-import { useRouter, useData, withBase } from 'vitepress';
-
-const router = useRouter();
-const { site } = useData();
-
-const {
-    login,
-    currentProvider,
-} = useAuthService();
-
-// Basic Auth form state
-const username = ref('');
-const password = ref('');
-// Supabase form state
-const email = ref('');
-const supabasePassword = ref('');
-const loginError = ref<string | null>(null);
-
-const handleAuth0Login = () => {
-    login();
-};
-
-const handleBasicLogin = async () => {
-    loginError.value = null;
-
-    try {
-        const success = await login({
-            username: username.value,
-            password: password.value
-        });
-
-        if (success) {
-            // Redirect to home page after successful login using base path from config
-            window.location.href = withBase('/');
-        } else {
-            loginError.value = 'Invalid username or password';
-        }
-    } catch (error) {
-        loginError.value = 'An error occurred during login';
-        console.error('Login error:', error);
-    }
-};
-
-const handleSupabaseLogin = async () => {
-    loginError.value = null;
-
-    try {
-        const success = await login({
-            email: email.value,
-            password: supabasePassword.value
-        });
-
-        if (success) {
-            // Redirect to home page after successful login
-            window.location.href = withBase('/');
-        } else {
-            loginError.value = 'Invalid email or password';
-        }
-    } catch (error) {
-        loginError.value = 'An error occurred during login';
-        console.error('Login error:', error);
-    }
-};
+import { withBase } from 'vitepress';
+import LoginForm from './LoginForm.vue';
 </script>
 
 <style>
@@ -153,53 +42,6 @@ const handleSupabaseLogin = async () => {
     color: var(--vp-c-brand);
 }
 
-.login-form {
-    margin-bottom: 1.5rem;
-}
-
-.form-group {
-    margin-bottom: 1rem;
-}
-
-.form-group label {
-    display: block;
-    margin-bottom: 0.5rem;
-    font-weight: 500;
-}
-
-.form-group input {
-    width: 100%;
-    padding: 0.75rem;
-    border: 1px solid var(--vp-c-divider);
-    border-radius: 4px;
-    background-color: var(--vp-c-bg);
-    color: var(--vp-c-text-1);
-}
-
-.login-button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    padding: 0.75rem;
-    font-size: 1rem;
-    font-weight: 500;
-    background-color: var(--vp-c-brand);
-    color: white;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    transition: all 0.2s ease;
-}
-
-.login-button:hover {
-    background-color: var(--vp-c-brand-dark);
-}
-
-.login-icon {
-    margin-right: 8px;
-}
-
 .home-link {
     margin-top: 1.5rem;
     text-align: center;
@@ -214,26 +56,7 @@ const handleSupabaseLogin = async () => {
     text-decoration: underline;
 }
 
-.auth-error {
-    background-color: #ffebee;
-    color: #c62828;
-    padding: 0.75rem;
-    border-radius: 4px;
-    margin-bottom: 1rem;
-    font-size: 0.9rem;
-}
-
-.login-info {
-    margin-top: 0.75rem;
-    text-align: center;
-    color: var(--vp-c-text-2);
-}
-
 /* Dark mode adjustments */
-.dark .auth-error {
-    background-color: rgba(244, 67, 54, 0.1);
-}
-
 .dark .login-container {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }

--- a/.vitepress/components/LoginPage.vue
+++ b/.vitepress/components/LoginPage.vue
@@ -22,6 +22,22 @@
                 </button>
             </div>
 
+            <!-- Supabase Login Form -->
+            <div v-else-if="currentProvider === 'supabase'" class="login-form">
+                <form @submit.prevent="handleSupabaseLogin">
+                    <div class="form-group">
+                        <label for="email">Email</label>
+                        <input type="email" id="email" v-model="email" placeholder="Enter email" required />
+                    </div>
+                    <div class="form-group">
+                        <label for="supabasePassword">Password</label>
+                        <input type="password" id="supabasePassword" v-model="supabasePassword"
+                            placeholder="Enter password" required />
+                    </div>
+                    <button type="submit" class="login-button">Sign In</button>
+                </form>
+            </div>
+
             <!-- Basic Auth Login Form -->
             <div v-else class="login-form">
                 <form @submit.prevent="handleBasicLogin">
@@ -35,7 +51,6 @@
                     </div>
                     <button type="submit" class="login-button">Sign In</button>
                 </form>
-
             </div>
 
             <div class="home-link">
@@ -61,6 +76,9 @@ const {
 // Basic Auth form state
 const username = ref('');
 const password = ref('');
+// Supabase form state
+const email = ref('');
+const supabasePassword = ref('');
 const loginError = ref<string | null>(null);
 
 const handleAuth0Login = () => {
@@ -81,6 +99,27 @@ const handleBasicLogin = async () => {
             window.location.href = withBase('/');
         } else {
             loginError.value = 'Invalid username or password';
+        }
+    } catch (error) {
+        loginError.value = 'An error occurred during login';
+        console.error('Login error:', error);
+    }
+};
+
+const handleSupabaseLogin = async () => {
+    loginError.value = null;
+
+    try {
+        const success = await login({
+            email: email.value,
+            password: supabasePassword.value
+        });
+
+        if (success) {
+            // Redirect to home page after successful login
+            window.location.href = withBase('/');
+        } else {
+            loginError.value = 'Invalid email or password';
         }
     } catch (error) {
         loginError.value = 'An error occurred during login';

--- a/.vitepress/components/LoginPage.vue
+++ b/.vitepress/components/LoginPage.vue
@@ -1,0 +1,201 @@
+<template>
+    <div class="login-page">
+        <div class="login-container">
+            <h1>Sign In</h1>
+
+            <div v-if="loginError" class="auth-error">
+                {{ loginError }}
+            </div>
+
+            <!-- Auth0 Login -->
+            <div v-if="currentProvider === 'auth0'" class="login-form">
+                <button class="login-button" @click="handleAuth0Login">
+                    <span class="login-icon">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4"></path>
+                            <polyline points="10 17 15 12 10 7"></polyline>
+                            <line x1="15" y1="12" x2="3" y2="12"></line>
+                        </svg>
+                    </span>
+                    Sign In
+                </button>
+            </div>
+
+            <!-- Basic Auth Login Form -->
+            <div v-else class="login-form">
+                <form @submit.prevent="handleBasicLogin">
+                    <div class="form-group">
+                        <label for="username">Username</label>
+                        <input type="text" id="username" v-model="username" placeholder="Enter username" required />
+                    </div>
+                    <div class="form-group">
+                        <label for="password">Password</label>
+                        <input type="password" id="password" v-model="password" placeholder="Enter password" required />
+                    </div>
+                    <button type="submit" class="login-button">Sign In</button>
+                </form>
+
+            </div>
+
+            <div class="home-link">
+                <a :href="withBase('/')">Return to Home Page</a>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useAuthService } from '../auth/authService';
+import { useRouter, useData, withBase } from 'vitepress';
+
+const router = useRouter();
+const { site } = useData();
+
+const {
+    login,
+    currentProvider,
+} = useAuthService();
+
+// Basic Auth form state
+const username = ref('');
+const password = ref('');
+const loginError = ref<string | null>(null);
+
+const handleAuth0Login = () => {
+    login();
+};
+
+const handleBasicLogin = async () => {
+    loginError.value = null;
+
+    try {
+        const success = await login({
+            username: username.value,
+            password: password.value
+        });
+
+        if (success) {
+            // Redirect to home page after successful login using base path from config
+            window.location.href = withBase('/');
+        } else {
+            loginError.value = 'Invalid username or password';
+        }
+    } catch (error) {
+        loginError.value = 'An error occurred during login';
+        console.error('Login error:', error);
+    }
+};
+</script>
+
+<style>
+.login-page {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    background-color: var(--vp-c-bg);
+    padding: 20px;
+}
+
+.login-container {
+    width: 100%;
+    max-width: 400px;
+    padding: 2rem;
+    background-color: var(--vp-c-bg-soft);
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.login-container h1 {
+    margin-bottom: 1.5rem;
+    text-align: center;
+    color: var(--vp-c-brand);
+}
+
+.login-form {
+    margin-bottom: 1.5rem;
+}
+
+.form-group {
+    margin-bottom: 1rem;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+}
+
+.form-group input {
+    width: 100%;
+    padding: 0.75rem;
+    border: 1px solid var(--vp-c-divider);
+    border-radius: 4px;
+    background-color: var(--vp-c-bg);
+    color: var(--vp-c-text-1);
+}
+
+.login-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    padding: 0.75rem;
+    font-size: 1rem;
+    font-weight: 500;
+    background-color: var(--vp-c-brand);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.login-button:hover {
+    background-color: var(--vp-c-brand-dark);
+}
+
+.login-icon {
+    margin-right: 8px;
+}
+
+.home-link {
+    margin-top: 1.5rem;
+    text-align: center;
+}
+
+.home-link a {
+    color: var(--vp-c-brand);
+    text-decoration: none;
+}
+
+.home-link a:hover {
+    text-decoration: underline;
+}
+
+.auth-error {
+    background-color: #ffebee;
+    color: #c62828;
+    padding: 0.75rem;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+}
+
+.login-info {
+    margin-top: 0.75rem;
+    text-align: center;
+    color: var(--vp-c-text-2);
+}
+
+/* Dark mode adjustments */
+.dark .auth-error {
+    background-color: rgba(244, 67, 54, 0.1);
+}
+
+.dark .login-container {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+</style>

--- a/.vitepress/components/LogoutButton.vue
+++ b/.vitepress/components/LogoutButton.vue
@@ -1,13 +1,9 @@
 <template>
-  <button 
-    v-if="isAuthenticated && !loading" 
-    class="logout-btn"
-    title="Log out" 
-    @click="handleLogout"
-    aria-label="Log out"
-  >
+  <button v-if="isAuthenticated && !loading" class="logout-btn" title="Log out" @click="handleLogout"
+    aria-label="Log out">
     <span class="logout-icon">
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path>
         <polyline points="16 17 21 12 16 7"></polyline>
         <line x1="21" y1="12" x2="9" y2="12"></line>
@@ -17,9 +13,9 @@
 </template>
 
 <script setup lang="ts">
-import { useAuth } from '../auth/auth0Service';
+import { useAuthService } from '../auth/authService';
 
-const { isAuthenticated, loading, logout } = useAuth();
+const { isAuthenticated, loading, logout } = useAuthService();
 
 const handleLogout = () => {
   logout();
@@ -59,7 +55,7 @@ const handleLogout = () => {
   .logout-text {
     display: none;
   }
-  
+
   .logout-btn {
     padding: 0.5rem;
   }

--- a/.vitepress/components/UserProfile.vue
+++ b/.vitepress/components/UserProfile.vue
@@ -8,16 +8,16 @@
 </template>
 
 <script setup lang="ts">
-import { useAuth } from '../auth/auth0Service';
+import { useAuthService } from '../auth/authService';
 import { computed } from 'vue';
 
-const { user, isAuthenticated } = useAuth();
+const { user, isAuthenticated } = useAuthService();
 
 const userData = computed(() => user.value);
 
 const userInitials = computed(() => {
   if (!userData.value) return '';
-  
+
   const name = userData.value.name || userData.value.email || '';
   return name
     .split(' ')

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,57 +1,72 @@
-import { defineConfig } from 'vitepress'
-import { loadEnv } from 'vite'
+import { defineConfig } from "vitepress";
+import { loadEnv } from "vite";
 
-const env = loadEnv('', process.cwd(), '')
+const env = loadEnv("", process.cwd(), "");
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  base: '/vitepress-auth-template/',
+  base: "/vitepress-auth-template/",
   title: "Auth0 Vitepress Template",
   description: "Auth0 Vitepress Template",
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [
-      { text: 'Home', link: '/' },
-      { text: 'Protected', link: '/markdown-examples' },
-      { text: 'Public', link: '/non-protected' }
+      { text: "Home", link: "/" },
+      { text: "Protected", link: "/markdown-examples" },
+      { text: "Public", link: "/non-protected" },
     ],
 
     sidebar: [
       {
-        text: 'Examples',
+        text: "Examples",
         items: [
-          { text: 'Protected Markdown Examples', link: '/markdown-examples' },
-          { text: 'Runtime API Examples', link: '/api-examples' },
-          { text: 'Non-Protected Examples', link: '/non-protected' }
-        ]
-      }
+          { text: "Protected Markdown Examples", link: "/markdown-examples" },
+          { text: "Runtime API Examples", link: "/api-examples" },
+          { text: "Non-Protected Examples", link: "/non-protected" },
+        ],
+      },
     ],
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/Com-X/vitepress-auth-template' }
+      {
+        icon: "github",
+        link: "https://github.com/Com-X/vitepress-auth-template",
+      },
     ],
 
     // Explicitly disable Algolia search
     search: {
-      provider: 'local'
-    }
+      provider: "local",
+    },
   },
 
   // Define environment variables to expose to the client
   vite: {
     define: {
-      'import.meta.env.AUTH0_DOMAIN': JSON.stringify(env.AUTH0_DOMAIN || ''),
-      'import.meta.env.AUTH0_CLIENT_ID': JSON.stringify(env.AUTH0_CLIENT_ID || ''),
-      'import.meta.env.AUTH0_REDIRECT_URI': JSON.stringify(env.AUTH0_REDIRECT_URI || '')
+      "import.meta.env.AUTH0_DOMAIN": JSON.stringify(env.AUTH0_DOMAIN || ""),
+      "import.meta.env.AUTH0_CLIENT_ID": JSON.stringify(
+        env.AUTH0_CLIENT_ID || ""
+      ),
+      "import.meta.env.AUTH0_REDIRECT_URI": JSON.stringify(
+        env.AUTH0_REDIRECT_URI || ""
+      ),
+      "import.meta.env.DEFAULT_AUTH_PROVIDER": JSON.stringify(
+        env.DEFAULT_AUTH_PROVIDER || "auth0"
+      ),
+      "import.meta.env.BASIC_AUTH_USERNAME": JSON.stringify(
+        env.BASIC_AUTH_USERNAME || "admin"
+      ),
+      "import.meta.env.BASIC_AUTH_PASSWORD": JSON.stringify(
+        env.BASIC_AUTH_PASSWORD || "password"
+      ),
     },
     optimizeDeps: {
-      include: ['vue', '@auth0/auth0-spa-js']
+      include: ["vue", "@auth0/auth0-spa-js"],
     },
     server: {
       fs: {
-        allow: ['..']
-      }
+        allow: [".."],
+      },
     },
-      
-  }
-})
+  },
+});

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -59,6 +59,10 @@ export default defineConfig({
       "import.meta.env.BASIC_AUTH_PASSWORD": JSON.stringify(
         env.BASIC_AUTH_PASSWORD || "password"
       ),
+      "import.meta.env.SUPABASE_URL": JSON.stringify(env.SUPABASE_URL || ""),
+      "import.meta.env.SUPABASE_ANON_KEY": JSON.stringify(
+        env.SUPABASE_ANON_KEY || ""
+      ),
     },
     optimizeDeps: {
       include: ["vue", "@auth0/auth0-spa-js"],

--- a/.vitepress/theme/LoginLayout.vue
+++ b/.vitepress/theme/LoginLayout.vue
@@ -1,0 +1,14 @@
+<template>
+    <div class="login-layout">
+        <slot></slot>
+    </div>
+</template>
+
+<style>
+.login-layout {
+    min-height: 100vh;
+    width: 100%;
+    background-color: var(--vp-c-bg);
+    color: var(--vp-c-text-1);
+}
+</style>

--- a/api-examples.md
+++ b/api-examples.md
@@ -11,6 +11,8 @@ This page provides a comprehensive tutorial on the core Runtime APIs available i
 // Import only the necessary APIs
 import { useData, useRoute, useRouter } from 'vitepress';
 
+import { withBase } from 'vitepress';
+
 // Only execute client-side code when in browser context
 const isBrowser = typeof window !== 'undefined';
 
@@ -109,8 +111,8 @@ function navigate(path) {
 #### Live Example
 
 <div class="api-example-box">
-  <button class="custom-button" @click="router.go('/')">Go Home</button>
-  <button class="custom-button" @click="router.go('/markdown-examples')">Go to Markdown Examples</button>
+  <button class="custom-button" @click="router.go(withBase('/'))">Go Home</button>
+  <button class="custom-button" @click="router.go(withBase('/markdown-examples'))">Go to Markdown Examples</button>
 </div>
 
 <style>

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@
 layout: home
 
 hero:
-  name: "Auth0 Vitepress Template"
+  name: "Auth Vitepress Template"
   tagline: Authenticated Docs in 5 Minutes
   actions:
     - theme: brand

--- a/login.md
+++ b/login.md
@@ -1,0 +1,16 @@
+---
+title: Sign In
+layout: false
+---
+
+<LoginPage />
+
+<script setup>
+import LoginPage from './.vitepress/components/LoginPage.vue'
+</script>
+
+<style>
+:root {
+  --vp-layout-max-width: 100%;
+}
+</style> 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "1.20.0",
+    "@supabase/supabase-js": "^2.49.2",
     "vite": "6.2.1",
     "vitepress": "1.6.3",
     "vue": "3.5.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@auth0/auth0-spa-js':
         specifier: 1.20.0
         version: 1.20.0
+      '@supabase/supabase-js':
+        specifier: ^2.49.2
+        version: 2.49.2
       vite:
         specifier: 6.2.1
         version: 6.2.1(@types/node@22.13.10)
@@ -426,6 +429,28 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@supabase/auth-js@2.69.0':
+    resolution: {integrity: sha512-y3x/oYxBVjEsM+YJCFDnPqB017pb8nBcC+E6ieUJmf7LtfkcqfeSo06ZqNIjVw3w0k1PJRiXwKvTxBhBTxrqPg==}
+
+  '@supabase/functions-js@2.4.4':
+    resolution: {integrity: sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==}
+
+  '@supabase/node-fetch@2.6.15':
+    resolution: {integrity: sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==}
+    engines: {node: 4.x || >=6.0.0}
+
+  '@supabase/postgrest-js@1.19.2':
+    resolution: {integrity: sha512-MXRbk4wpwhWl9IN6rIY1mR8uZCCG4MZAEji942ve6nMwIqnBgBnZhZlON6zTTs6fgveMnoCILpZv1+K91jN+ow==}
+
+  '@supabase/realtime-js@2.11.2':
+    resolution: {integrity: sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==}
+
+  '@supabase/storage-js@2.7.1':
+    resolution: {integrity: sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==}
+
+  '@supabase/supabase-js@2.49.2':
+    resolution: {integrity: sha512-ANbmL72JDY9atLZwedq0dLosVR+JM4qJZx3Un9Ip7kB4TZ8u2RrUFt1/ug4Bykm1h6UcQuHvxCkbrVIDTfUNvg==}
+
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
@@ -447,11 +472,17 @@ packages:
   '@types/node@22.13.10':
     resolution: {integrity: sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==}
 
+  '@types/phoenix@1.6.6':
+    resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
+  '@types/ws@8.18.0':
+    resolution: {integrity: sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -766,6 +797,9 @@ packages:
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -887,10 +921,28 @@ packages:
       typescript:
         optional: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  ws@8.18.1:
+    resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -1229,6 +1281,48 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@supabase/auth-js@2.69.0':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/functions-js@2.4.4':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/node-fetch@2.6.15':
+    dependencies:
+      whatwg-url: 5.0.0
+
+  '@supabase/postgrest-js@1.19.2':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/realtime-js@2.11.2':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+      '@types/phoenix': 1.6.6
+      '@types/ws': 8.18.0
+      ws: 8.18.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.7.1':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/supabase-js@2.49.2':
+    dependencies:
+      '@supabase/auth-js': 2.69.0
+      '@supabase/functions-js': 2.4.4
+      '@supabase/node-fetch': 2.6.15
+      '@supabase/postgrest-js': 1.19.2
+      '@supabase/realtime-js': 2.11.2
+      '@supabase/storage-js': 2.7.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@types/estree@1.0.6': {}
 
   '@types/hast@3.0.4':
@@ -1252,9 +1346,15 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
+  '@types/phoenix@1.6.6': {}
+
   '@types/unist@3.0.3': {}
 
   '@types/web-bluetooth@0.0.21': {}
+
+  '@types/ws@8.18.0':
+    dependencies:
+      '@types/node': 22.13.10
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -1629,6 +1729,8 @@ snapshots:
 
   tabbable@6.2.0: {}
 
+  tr46@0.0.3: {}
+
   trim-lines@3.0.1: {}
 
   undici-types@6.20.0: {}
@@ -1743,8 +1845,17 @@ snapshots:
       '@vue/server-renderer': 3.5.13(vue@3.5.13)
       '@vue/shared': 3.5.13
 
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  ws@8.18.1: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Overview
This pull request adds a new authentication option using Supabase, allowing users to sign in with email and password credentials through Supabase authentication services alongside the existing Auth0 and Basic Auth methods. Now the system supports three authentication providers: Auth0, Basic Auth, and Supabase.

## Changes
- Added Supabase authentication service implementation with login, logout, and session management
- Updated the authentication provider system to include Supabase as an option
- Extended the login form component to support Supabase email/password authentication flow
- Added Supabase configuration options to environment variables
- Updated the main authentication service to properly handle the new provider
- Added proper error handling and loading states for Supabase authentication

## Authentication Options
1. **Auth0** - OAuth2-based authentication using Auth0 services
2. **Basic Auth** - Simple username/password authentication for development and testing purposes
3. **Supabase** - Email/password authentication through Supabase services

## Configuration
- Added `SUPABASE_URL` and `SUPABASE_ANON_KEY` environment variables
- Updated `DEFAULT_AUTH_PROVIDER` to accept "supabase" as a valid option (alongside existing "auth0" and "basic" options)

## Dependencies
- Added Supabase JavaScript client (`@supabase/supabase-js`) for authentication operations

## How to test
1. Set up a Supabase project and obtain your project URL and anon key
2. Configure the `.env` file with your Supabase credentials
3. Set `DEFAULT_AUTH_PROVIDER="supabase"` to make it the default authentication method
4. Run the application and test the login functionality with valid Supabase credentials

This enhancement gives users more flexibility in how they implement authentication in their VitePress sites, providing a modern alternative to Auth0 and basic authentication.